### PR TITLE
Support database selection

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -97,7 +97,12 @@ class Redis implements Adapter
             if ($this->options['password']) {
                 $this->redis->auth($this->options['password']);
             }
+            if (isset($this->options['database'])) {
+                $this->redis->select($this->options['database']);
+            }
+
             $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->options['read_timeout']);
+            
         } catch (\RedisException $e) {
             throw new StorageException("Can't connect to Redis server", 0, $e);
         }


### PR DESCRIPTION
In order to allow the use of different databases in Redis, the
connection now supports switching to a new database.

One important factor to understand here is that if you are using
`pconnect` and you do a `select` operation, you may be changing the same
connection the rest of your code is using.